### PR TITLE
Adjusted Coordinates

### DIFF
--- a/2DRPG/Form1.cs
+++ b/2DRPG/Form1.cs
@@ -79,6 +79,13 @@ namespace _2DRPG {
 			OrthoTop += y;
 			OrthoBottom += y;
 		}
+
+		public static void SetOrtho(double x, double y) {
+			OrthoLeft = x;
+			OrthoRight = x;
+			OrthoTop = y;
+			OrthoBottom = y;
+		}
 		private static double OrthoLeft = 0;
 		private static double OrthoRight = 0;
 		private static double OrthoTop = 0;
@@ -88,8 +95,9 @@ namespace _2DRPG {
 		private void RenderControl_Render_GL(object sender, GlControlEventArgs e) {
 			Gl.MatrixMode(MatrixMode.Projection);
 			Gl.LoadIdentity();
-			Gl.Ortho(-Screen.screenWidth / 2 + OrthoLeft * Screen.screenHeight / 2, Screen.screenWidth / 2 + OrthoRight * Screen.screenHeight / 2, (-1 + OrthoBottom) * Screen.screenHeight / 2, (1 + OrthoTop) * Screen.screenHeight / 2, -0.1, 10.0);
-			Gl.ClearColor(Color.Aqua.R, Color.Aqua.G, Color.Aqua.B, Color.Aqua.A);
+			//Gl.Ortho(-Screen.screenWidth / 2 + OrthoLeft * Screen.screenHeight / 2, Screen.screenWidth / 2 + OrthoRight * Screen.screenHeight / 2, (-1 + OrthoBottom) * Screen.screenHeight / 2, (1 + OrthoTop) * Screen.screenHeight / 2, -0.1, 10.0);
+			Gl.Ortho(0 + OrthoLeft, Screen.pixelWidth + OrthoRight, 0 + OrthoBottom, Screen.pixelHeight + OrthoTop, -.1, 10);
+			Gl.ClearColor(Color.White.R, Color.White.G, Color.White.B, Color.White.A);
 			Gl.Clear(ClearBufferMask.ColorBufferBit | ClearBufferMask.DepthBufferBit);
 
 			List<World.Objects.WorldObjectBase>[] tobjects = WorldData.currentRegions.Values.ToArray();     //Render the World Objects
@@ -101,7 +109,7 @@ namespace _2DRPG {
 			//Load a separete projection for GUI rendering that doesn't move with the character
 			Gl.MatrixMode(MatrixMode.Projection);
 			Gl.LoadIdentity();
-			Gl.Ortho(-Screen.screenWidth / 2, Screen.screenWidth / 2, -Screen.screenHeight / 2, Screen.screenHeight / 2, -0.1, 10.0);
+			Gl.Ortho(0, Screen.pixelWidth, 0, Screen.pixelHeight, -.1, 10);
 
 			GUI.UIBase[] guiObjects = Screen.UIObjects.ToArray();   //Render the GUI Objects
 			foreach (GUI.UIBase u in guiObjects) {

--- a/2DRPG/GUI/UIBase.cs
+++ b/2DRPG/GUI/UIBase.cs
@@ -24,14 +24,14 @@ namespace _2DRPG.GUI {
 		public override void SetScreenPosition(float x, float y) {
 			screenX = x;
 			screenY = y;
-			arrayPosition[0] = x - width;
-			arrayPosition[3] = x - width;
-			arrayPosition[6] = x + width;
-			arrayPosition[9] = x + width;
-			arrayPosition[1] = y - height;
-			arrayPosition[10] = y - height;
-			arrayPosition[4] = y + height;
-			arrayPosition[7] = y + height;
+			arrayPosition[0] = x - width / 2 - .5f;
+			arrayPosition[3] = x - width / 2 - .5f;
+			arrayPosition[6] = x + width / 2 + .5f;
+			arrayPosition[9] = x + width / 2 + .5f;
+			arrayPosition[1] = y - height / 2 - .5f;
+			arrayPosition[10] = y - height / 2 - .5f;
+			arrayPosition[4] = y + height / 2 + .5f;
+			arrayPosition[7] = y + height / 2 + .5f;
 		}
 		public override void SetScreenPosition(float x, float y, int layer) {
 			SetScreenPosition(x, y);

--- a/2DRPG/GUI/UIDropdownButton.cs
+++ b/2DRPG/GUI/UIDropdownButton.cs
@@ -9,7 +9,7 @@ namespace _2DRPG.GUI {
 
 		private List<UIButton> drops = new List<UIButton>();
 		private bool showDrops = false;
-		private float spacing = .05f; //gap between buttons displayed in the dropdown
+		private float spacing = 4f; //gap between buttons displayed in the dropdown
 
 		public UIDropdownButton(float x, float y, float width, float height, UIButton[] dropdowns) : this(x, y, width, height, null, dropdowns) { }
 		public UIDropdownButton(float x, float y, float width, float height, string labelText, UIButton[] dropdowns) : base(x, y, width, height, 1, "Button") {
@@ -19,7 +19,7 @@ namespace _2DRPG.GUI {
 			foreach (UIButton b in dropdowns) {
 				b.width = width;
 				b.height = height;
-				b.SetScreenPosition(x, y - counter++ * height * (2 + spacing));
+				b.SetScreenPosition(x, y - counter++ * (height + spacing));
 				drops.Add(b);
 			}
 			buttonAction = new Action(ToggleDropdowns);

--- a/2DRPG/GUI/UIText.cs
+++ b/2DRPG/GUI/UIText.cs
@@ -5,21 +5,27 @@ using System.Text;
 using System.Threading.Tasks;
 
 namespace _2DRPG.GUI {
-	class UIText  : UIBase {
+	class UIText : UIBase {
 
 		private string displayText;
 		private List<UIChar> chars = new List<UIChar>();
 
-		public UIText(float x, float y, float width, float height, string text) : base(x, y, width, height, 1, "Default") {
+		public UIText(float x, float y, float width, float height, string text) : base(x, y, width, height, 1, "Button") {
 			displayText = text;
 			SetupChars();
 		}
 
 		public override void Render() {
+			base.Render();
 			UIChar[] renderC = chars.ToArray();
 			foreach (UIChar c in renderC)
 				c.Render();
+			
+		}
 
+		public void SetText(string text) {
+			displayText = text;
+			SetupChars();
 		}
 
 		private void SetupChars() {
@@ -30,7 +36,7 @@ namespace _2DRPG.GUI {
 			float charSize, startX, startY;
 			if (width / characters.Length < height) {
 				charSize = width / characters.Length;
-				startX = screenX - width/2;
+				startX = screenX - width/4;
 				startY = screenY + (height - charSize) / 2 - height/3;
 			} else {
 				charSize = height;

--- a/2DRPG/Input.cs
+++ b/2DRPG/Input.cs
@@ -58,8 +58,8 @@ namespace _2DRPG {
 		public static void MouseSent(object sender, MouseEventArgs e) {
 			if (e.Button.Equals(MouseButtons.Left)) {
 				GUI.UIBase[] guiObjects = Screen.UIObjects.ToArray();   
-				float checkX = Screen.windowRatio * 2 * ((float)e.X / Screen.WindowWidth - .5f);	//Convert from mouse coordinates to screen coordinates
-				float checkY = 2 * (.5f - (float)e.Y / Screen.WindowHeight);
+				float checkX = (float)e.X / Screen.WindowWidth * Screen.pixelWidth;	//Convert from mouse coordinates to screen coordinates
+				float checkY = (1f - (float)e.Y / Screen.WindowHeight) * Screen.pixelHeight;
 				foreach (GUI.UIBase u in guiObjects) {
 					if (u is GUI.UIButton)
 						((GUI.UIButton)u).CheckClick( checkX, checkY);

--- a/2DRPG/Player/MCObject.cs
+++ b/2DRPG/Player/MCObject.cs
@@ -9,7 +9,7 @@ namespace _2DRPG.Player {
 	class MCObject : WorldObjectControllable, IDamagable, IEffectable {
 
 		public MCObject() : base("heart") {
-			MovementSpeed = .020f;
+			MovementSpeed = 1f;
 		}
 		public void AddEffect(EntityEffect e) {
 			throw new NotImplementedException();

--- a/2DRPG/Screen.cs
+++ b/2DRPG/Screen.cs
@@ -14,17 +14,22 @@ namespace _2DRPG {
 		public static int screenHeight;
 		public static int screenWidth;
 
+		public static int pixelWidth = 496;
+		public static int pixelHeight = 279;
+
 		public static List<UIBase> UIObjects = new List<UIBase>();
 
+		public static UIText worldText = new UIText(400f, 200f, 100f, 30f, "Coords: ");
 		public static void ScreenStartup() {
 			LoadGUITextures();
 			//UIButton b = new UIButton(-1.7f, .8f, .1f, .1f, () => { System.Diagnostics.Debug.WriteLine("ayo"); });
 			//UIObjects.Add(b);
 			UIObjects.Add(new UIText(1f, 0f, .7f, .2f, "Test text"));
-			UIObjects.Add(new UIDropdownButton(-1.4f, .8f, .3f, .1f, "Dropdown", new UIButton[]{
+			UIObjects.Add(new UIDropdownButton(45f, 250f, 90f, 15f, "Dropdown", new UIButton[]{
 				new UIButton(() => { System.Diagnostics.Debug.WriteLine("1 Pressed"); }, "Button 1"),
 				new UIButton(() => { System.Diagnostics.Debug.WriteLine("2 Pressed"); }, "Button 2")
 			}));
+			UIObjects.Add(worldText);
 
 		}
 
@@ -52,6 +57,13 @@ namespace _2DRPG {
 			TextureManager.LoadTexture("Sprites/Heart.png", "Heart");
 			TextureManager.LoadTexture("Sprites/CourierFont.png", "CourierFont");
 			TextureManager.LoadTexture("Sprites/Default.png", "Default");
+		}
+		/// <summary>
+		/// Takes a value either [0, 16/9] for width or [0, 1] for height and returns the pixel number
+		/// </summary>
+		/// <returns></returns>
+		public static int NormalizedToScreen(float normalizedCoord) {
+			return (int)(normalizedCoord * 279);
 		}
 	}
 }

--- a/2DRPG/TextureManager.cs
+++ b/2DRPG/TextureManager.cs
@@ -34,13 +34,15 @@ namespace _2DRPG {
 					texSource.RotateFlip(RotateFlipType.RotateNoneFlipY);
 					uint id = Gl.GenTexture();
 					Gl.BindTexture(TextureTarget.Texture2d, id);
+					Gl.TexStorage2D(TextureTarget.Texture2d, 7, InternalFormat.Rgba, texSource.Width, texSource.Height);
 					Gl.TexParameter(TextureTarget.Texture2d, TextureParameterName.TextureMagFilter, (int)TextureMagFilter.Nearest); //Mipmap options
-					Gl.TexParameter(TextureTarget.Texture2d, TextureParameterName.TextureMinFilter, (int)TextureMinFilter.Nearest);
-					Gl.TexParameter(TextureTarget.Texture2d, TextureParameterName.TextureWrapS, (int)TextureWrapMode.Clamp);
-					Gl.TexParameter(TextureTarget.Texture2d, TextureParameterName.TextureWrapT, (int)TextureWrapMode.Clamp);
+					Gl.TexParameter(TextureTarget.Texture2d, TextureParameterName.TextureMinFilter, (int)TextureMinFilter.LinearMipmapLinear);
+					Gl.TexParameter(TextureTarget.Texture2d, TextureParameterName.TextureWrapS, (int)TextureWrapMode.ClampToEdge);
+					Gl.TexParameter(TextureTarget.Texture2d, TextureParameterName.TextureWrapT, (int)TextureWrapMode.ClampToEdge);
 					Gl.TexImage2D(TextureTarget.Texture2d, 0, InternalFormat.Rgba, texSource.Width, texSource.Height, 0, OpenGL.PixelFormat.Bgra, PixelType.UnsignedByte, IntPtr.Zero);     //Sets up the blank GL 2d Texture
 					BitmapData bitmap_data = texSource.LockBits(new Rectangle(0, 0, texSource.Width, texSource.Height), ImageLockMode.ReadOnly, System.Drawing.Imaging.PixelFormat.Format32bppArgb);    //extracts the bitmap data
 					Gl.TexSubImage2D(TextureTarget.Texture2d, 0, 0, 0, texSource.Width, texSource.Height, OpenGL.PixelFormat.Bgra, PixelType.UnsignedByte, bitmap_data.Scan0);      //Adds the bitmap data to the texture
+					Gl.GenerateMipmap(TextureTarget.Texture2d);
 					texSource.UnlockBits(bitmap_data);
 					loadedTextureIDs.Add(textureName, id);
 					Gl.BindTexture(TextureTarget.Texture2d, 0);

--- a/2DRPG/TexturedObject.cs
+++ b/2DRPG/TexturedObject.cs
@@ -37,7 +37,7 @@ namespace _2DRPG {
 
 		public void ContextUpdate() { }
 
-		public float size = .25f;
+		public float size = 16f;
 
 		public float[] arrayPosition = new float[] {
 			0.25f, 0.25f, 0f,
@@ -47,21 +47,14 @@ namespace _2DRPG {
 
 		};
 		public float[] texturePosition = new float[] {
-			0.0f, 0.0f,
-			0.0f, 1.0f,
-			1.0f, 1.0f,
-			1.0f, 0.0f
+			0.0f- 1/32f, 0.0f- 1/32f,
+			0.0f- 1/32f, 1.0f+ 1/32f,
+			1.0f+ 1/32f, 1.0f+ 1/32f,
+			1.0f+ 1/32f, 0.0f- 1/32f
 		};
 
 		public virtual void Render() {
-			float[] temparray = new float[arrayPosition.Length];
-			for (int i = 0; i < arrayPosition.Length; i++) {
-				if ((i + 1) % 3 != 0)
-					temparray[i] = (float)Math.Ceiling(arrayPosition[i] * Screen.screenHeight / 2);
-				else
-					temparray[i] = arrayPosition[i];
-			}
-			using (MemoryLock vertexArrayLock = new MemoryLock(temparray))
+			using (MemoryLock vertexArrayLock = new MemoryLock(arrayPosition))
 			using (MemoryLock vertexTextureLock = new MemoryLock(texturePosition)) {
 				Gl.BlendFunc(BlendingFactor.SrcAlpha, BlendingFactor.OneMinusSrcAlpha);
 				//Sets the texture used

--- a/2DRPG/World/Objects/WorldObjectBase.cs
+++ b/2DRPG/World/Objects/WorldObjectBase.cs
@@ -24,5 +24,17 @@ namespace _2DRPG.World.Objects {
 			worldX = x;
 			worldY = y;
 		}
+
+		public override void Render() {
+			arrayPosition[0] = worldX - size / 2 - .5f;
+			arrayPosition[3] = worldX - size / 2 - .5f;
+			arrayPosition[6] = worldX + size / 2 + .5f;
+			arrayPosition[9] = worldX + size / 2 + .5f;
+			arrayPosition[1] = worldY - size / 2 - .5f;
+			arrayPosition[10] = worldY - size / 2 - .5f;
+			arrayPosition[4] = worldY + size / 2 + .5f;
+			arrayPosition[7] = worldY + size / 2 + .5f;
+			base.Render();
+		}
 	}
 }

--- a/2DRPG/World/Regions/Region0x0.cs
+++ b/2DRPG/World/Regions/Region0x0.cs
@@ -20,9 +20,9 @@ namespace _2DRPG.World.Regions {
 			regionObjects.Clear();
 			MCObject t = new MCObject();
 			WorldObjectBase j = new WorldObjectBase();
-            WorldObjectAnimated flower = new WorldObjectAnimated(-1.5f,.2f,1,4,16,16,15, "flower");
-			j.SetWorldPosition(0.2f, 0.1f);
-			regionObjects.Add(new WorldObjectBase(.45f, .1f, "default"));
+            WorldObjectAnimated flower = new WorldObjectAnimated(-16f,16f,1,4,16,16,15, "flower");
+			j.SetWorldPosition(16f, 16f);
+			regionObjects.Add(new WorldObjectBase(0f, 0f, "default"));
 			t.SetLayer(2);
 			regionObjects.Add(t);
 			regionObjects.Add(j);

--- a/2DRPG/WorldData.cs
+++ b/2DRPG/WorldData.cs
@@ -50,7 +50,7 @@ namespace _2DRPG {
 				}
 				currentRegions.Add(reg, tempReg);
 			}
-			SetScreenCoords();
+			//SetScreenCoords();
 		}
 		private static void UnloadRegion(int rx, int ry) {
 			string reg = rx + "x" + ry;
@@ -68,6 +68,7 @@ namespace _2DRPG {
 			TextureManager.ClearTextures();
 
 			LoadRegionObjects();
+			SetCenter(0, 0);
 		}
 
 		/// <summary>
@@ -80,8 +81,8 @@ namespace _2DRPG {
 			int oldY = CurrentRegionY;
 			CurrentX += x;
 			CurrentY += y;
-			CurrentRegionX = (int)CurrentX % 100;
-			CurrentRegionY = (int)CurrentY % 100;
+			CurrentRegionX = (int)Math.Ceiling(CurrentX / 1000) - 1 ;
+			CurrentRegionY = (int)Math.Ceiling(CurrentY / 1000) - 1;
 			Form1.ShiftOrtho(x, y);
 			oldX = CurrentRegionX - oldX;
 			oldY = CurrentRegionY - oldY;
@@ -93,10 +94,12 @@ namespace _2DRPG {
 				UnloadRegion(CurrentRegionX, CurrentRegionY - (oldY * 2));
 				LoadRegion(CurrentRegionX, CurrentRegionY + oldY);
 			}
+			Screen.worldText.SetText("Coords: " + CurrentRegionX + ", " + CurrentRegionY + " : " + CurrentX + ", " + CurrentY);
 		}
 		public static void SetCenter(float x, float y) {
-			CurrentX = x;
-			CurrentY = y;
+			CurrentX = x - Screen.pixelWidth / 2;
+			CurrentY = y - Screen.pixelHeight / 2;
+			Form1.SetOrtho(CurrentX, CurrentY);
 			//SetScreenCoords();
 		}
 


### PR DESCRIPTION
Moved the Orthographic projection again into the 496x279 coordinate
system that was previously decided upon. Most things are updated to
reflect the move from float coordinates into quantized (hopefully)
texture units that are then mapped to the screen via the ortho. Also
fixed the region detection code, though it needs to be tweaked with the
coordinate system, as 100x100 is smaller than just what the screen
displays, 1000x1000 is most likely a temporary fix, though it might
stay. Also enabled mipmapping and messed around with the filtering
options: linear needs to be enabled for text, but keep nearest for the
rest of the textures.